### PR TITLE
using chonicles to display server ready, fixes #62

### DIFF
--- a/graphql/httpserver.nim
+++ b/graphql/httpserver.nim
@@ -163,8 +163,9 @@ proc state*(rs: GraphqlHttpServerRef): GraphqlHttpServerState {.raises: [Defect]
 
 proc start*(rs: GraphqlHttpServerRef) =
   ## Starts GraphQL server.
-  rs.server.start()
-  notice "GraphQL service started", address = $rs.server.address
+  rs.server.start()  
+  notice "GraphQL service started", at = "http://" & $rs.server.address & "/graphql"
+  notice "GraphiQL UI ready", at = "http://" & $rs.server.address & "/graphql/ui"
 
 proc stop*(rs: GraphqlHttpServerRef) {.async.} =
   ## Stop GraphQL server from accepting new connections.

--- a/playground/swserver.nim
+++ b/playground/swserver.nim
@@ -53,9 +53,6 @@ proc main() =
   let server = sres.get()
   server.start()
 
-  echo ""
-  echo "server ready at http://" & $address & "/graphql"
-  echo "graphiql ui ready at http://" & $address & "/graphql/ui"
   runForever()
 
 main()


### PR DESCRIPTION
when the server already started,
display '/graphql' and 'graphql/ui' endpoint