### PR TITLE
Specify `maxResponseHeadersSize` when initializing HTTP client

### DIFF
--- a/graphql/httpclient.nim
+++ b/graphql/httpclient.nim
@@ -274,7 +274,7 @@ proc sendRequest*(ctx: GraphqlHttpClientRef, query: string,
       HttpClientRequestRef.new(
         ctx.session, ctx.address,
         ctx.meth, ctx.version, {},
-        HttpMaxHeadersSize, newHeaders, body
+        headers = newHeaders, body = body
       )
 
     let resp = await request.send()

--- a/graphql/httpclient.nim
+++ b/graphql/httpclient.nim
@@ -274,7 +274,7 @@ proc sendRequest*(ctx: GraphqlHttpClientRef, query: string,
       HttpClientRequestRef.new(
         ctx.session, ctx.address,
         ctx.meth, ctx.version, {},
-        newHeaders, body
+        HttpMaxHeadersSize, newHeaders, body
       )
 
     let resp = await request.send()


### PR DESCRIPTION
Update to be compatible with newer Chronos versions that have an additional argument when instantiating `HttpClientRequestRef`.